### PR TITLE
Refactor/hooks

### DIFF
--- a/src/app/films/components/FilmDetails/index.tsx
+++ b/src/app/films/components/FilmDetails/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@components/ui/card'
 import { Skeleton } from '@components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@components/ui/tabs'
-import { useFilmsById } from '@lib/hooks/films'
+import { useFilmsById } from '@lib/hooks/films/useFilmsById'
 import { useRelatedEntities } from '@lib/hooks/useRelatedEntities'
 import { ArrowLeft, Leaf, MapPin, Star, Tractor, Users } from 'lucide-react'
 import Image from 'next/image'

--- a/src/app/films/components/FilmsList/useFilmsListController.ts
+++ b/src/app/films/components/FilmsList/useFilmsListController.ts
@@ -1,5 +1,5 @@
 import { useGhibliContext } from '@lib/contexts/GhibliContext'
-import { useFilms } from '@lib/hooks/films'
+import { useFilms } from '@lib/hooks/films/useFilms'
 
 export function useFilmsListController() {
   const { data: films, isLoading, error } = useFilms()

--- a/src/components/FIlmsCarousel.tsx
+++ b/src/components/FIlmsCarousel.tsx
@@ -18,7 +18,7 @@ import {
   CarouselItem,
 } from '@components/ui/carousel'
 import { Skeleton } from '@components/ui/skeleton'
-import { useFilms } from '@lib/hooks/films'
+import { useFilms } from '@lib/hooks/films/useFilms'
 import Autoplay from 'embla-carousel-autoplay'
 import { Star } from 'lucide-react'
 import Image from 'next/image'

--- a/src/lib/hooks/films/useFilms.ts
+++ b/src/lib/hooks/films/useFilms.ts
@@ -8,12 +8,3 @@ export function useFilms() {
     staleTime: Infinity,
   })
 }
-
-export function useFilmsById(id: string) {
-  return useQuery({
-    queryKey: ['films', id],
-    queryFn: () => filmsService.getById(id),
-    staleTime: Infinity,
-    enabled: !!id,
-  })
-}

--- a/src/lib/hooks/films/useFilmsById.ts
+++ b/src/lib/hooks/films/useFilmsById.ts
@@ -1,0 +1,11 @@
+import { filmsService } from '@lib/services/films'
+import { useQuery } from '@tanstack/react-query'
+
+export function useFilmsById(id: string) {
+  return useQuery({
+    queryKey: ['films', id],
+    queryFn: () => filmsService.getById(id),
+    staleTime: Infinity,
+    enabled: !!id,
+  })
+}

--- a/src/lib/hooks/locations/useLocationById.ts
+++ b/src/lib/hooks/locations/useLocationById.ts
@@ -1,0 +1,11 @@
+import { locationsService } from '@lib/services/locations'
+import { useQuery } from '@tanstack/react-query'
+
+export function useLocationById(id: string) {
+  return useQuery({
+    queryKey: ['location', id],
+    queryFn: () => locationsService.getById(id),
+    staleTime: Infinity,
+    enabled: !!id,
+  })
+}

--- a/src/lib/hooks/locations/useLocations.ts
+++ b/src/lib/hooks/locations/useLocations.ts
@@ -8,12 +8,3 @@ export function useLocations() {
     staleTime: Infinity,
   })
 }
-
-export function useLocationsById(id: string) {
-  return useQuery({
-    queryKey: ['location', id],
-    queryFn: () => locationsService.getById(id),
-    staleTime: Infinity,
-    enabled: !!id,
-  })
-}

--- a/src/lib/hooks/people/usePeople.ts
+++ b/src/lib/hooks/people/usePeople.ts
@@ -8,12 +8,3 @@ export function usePeople() {
     staleTime: Infinity,
   })
 }
-
-export function usePeopleById(id: string) {
-  return useQuery({
-    queryKey: ['people', id],
-    queryFn: () => peoplesService.getById(id),
-    staleTime: Infinity,
-    enabled: !!id,
-  })
-}

--- a/src/lib/hooks/people/usePeopleById.ts
+++ b/src/lib/hooks/people/usePeopleById.ts
@@ -1,0 +1,11 @@
+import { peoplesService } from '@lib/services/peoples'
+import { useQuery } from '@tanstack/react-query'
+
+export function usePeopleById(id: string) {
+  return useQuery({
+    queryKey: ['people', id],
+    queryFn: () => peoplesService.getById(id),
+    staleTime: Infinity,
+    enabled: !!id,
+  })
+}

--- a/src/lib/hooks/species/useSpecieById.ts
+++ b/src/lib/hooks/species/useSpecieById.ts
@@ -1,0 +1,11 @@
+import { speciesService } from '@lib/services/species'
+import { useQuery } from '@tanstack/react-query'
+
+export function useSpecieById(id: string) {
+  return useQuery({
+    queryKey: ['species', id],
+    queryFn: () => speciesService.getById(id),
+    staleTime: Infinity,
+    enabled: !!id,
+  })
+}

--- a/src/lib/hooks/species/useSpecies.ts
+++ b/src/lib/hooks/species/useSpecies.ts
@@ -8,12 +8,3 @@ export function useSpecies() {
     staleTime: Infinity,
   })
 }
-
-export function useSpeciesById(id: string) {
-  return useQuery({
-    queryKey: ['species', id],
-    queryFn: () => speciesService.getById(id),
-    staleTime: Infinity,
-    enabled: !!id,
-  })
-}

--- a/src/lib/hooks/vehicles/useVehicleById.ts
+++ b/src/lib/hooks/vehicles/useVehicleById.ts
@@ -1,0 +1,11 @@
+import { vehiclesService } from '@lib/services/vehicles'
+import { useQuery } from '@tanstack/react-query'
+
+export function useVehicleById(id: string) {
+  return useQuery({
+    queryKey: ['vehicle', id],
+    queryFn: () => vehiclesService.getById(id),
+    staleTime: Infinity,
+    enabled: !!id,
+  })
+}

--- a/src/lib/hooks/vehicles/useVehicles.ts
+++ b/src/lib/hooks/vehicles/useVehicles.ts
@@ -8,12 +8,3 @@ export function useVehicle() {
     staleTime: Infinity,
   })
 }
-
-export function useVehicleById(id: string) {
-  return useQuery({
-    queryKey: ['vehicle', id],
-    queryFn: () => vehiclesService.getById(id),
-    staleTime: Infinity,
-    enabled: !!id,
-  })
-}


### PR DESCRIPTION
## What's new
- **Refactored Data Hooks**: Split and reorganized hooks for films, locations, people, species, and vehicles into dedicated files for better modularity and clarity.

## Tech changes

### Films Hooks Refactor
Split `src/lib/hooks/films.ts` into `useFilms.ts` and `useFilmsById.ts`. `useFilms.ts` handles fetching all films, while `useFilmsById.ts` fetches a single film by ID. Updated imports in `src/app/films/components/FilmDetails/index.tsx` and `src/components/FIlmsCarousel.tsx` to use `useFilms` from the new path.

### Locations Hooks Refactor
Split `src/lib/hooks/locations.ts` into `useLocations.ts` and `useLocationById.ts`. `useLocations.ts` fetches all locations, and `useLocationById.ts` fetches a single location by ID. Renamed `useLocationsById` to `useLocationById` for consistency.

### People Hooks Refactor
Split `src/lib/hooks/people.ts` into `usePeople.ts` and `usePeopleById.ts`. `usePeople.ts` fetches all people, and `usePeopleById.ts` fetches a single person by ID.

### Species Hooks Refactor
Split `src/lib/hooks/species.ts` into `useSpecies.ts` and `useSpecieById.ts`. `useSpecies.ts` fetches all species, and `useSpecieById.ts` fetches a single species by ID. Renamed `useSpeciesById` to `useSpecieById` for grammatical accuracy.

### Vehicles Hooks Refactor
Split `src/lib/hooks/vehicles.ts` into `useVehicles.ts` and `useVehicleById.ts`. `useVehicles.ts` fetches all vehicles, and `useVehicleById.ts` fetches a single vehicle by ID.